### PR TITLE
Implement to_cudf method for reading directly into GPU memory

### DIFF
--- a/intake_parquet/source.py
+++ b/intake_parquet/source.py
@@ -11,8 +11,8 @@ class ParquetSource(base.DataSource):
     A parquet dataset may be a single file, a set of files in a single
     directory or a nested set of directories containing data-files.
 
-    The implementation uses either fastparquet or pyarrow, select with the
-    `engine=` kwarg.
+    The implementation uses either fastparquet, pyarrow or cudf, select with
+    the `engine=` kwarg.
 
     Keyword parameters accepted by this Source:
 
@@ -29,9 +29,8 @@ class ParquetSource(base.DataSource):
         ``x``, then it will be skipped. Row-level filtering is *not*
         performed.
 
-    - engine: 'fastparquet' or 'pyarrow'
+    - engine: 'fastparquet', 'pyarrow' or 'cudf'
         Which backend to read with.
-
 
     - gather_statistics : bool or None (default).
         Gather the statistics for each dataset partition. By default,
@@ -108,6 +107,15 @@ class ParquetSource(base.DataSource):
         self._df = dd.read_parquet(urlpath,
                                    storage_options=self._storage_options, **self._kwargs)
         self._load_metadata()
+        return self._df
+
+    def to_cudf(self):
+        """
+        Load a Parquet dataset into a GPU-backed cudf.DataFrame
+        """
+        import cudf
+
+        self._df = cudf.read_parquet(filepath_or_buffer=self._urlpath, **self._kwargs)
         return self._df
 
     def _close(self):

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -128,3 +128,10 @@ def test_with_cache():
     finally:
         shutil.rmtree(d)
         intake.config.conf['cache_dir'] = old
+
+def test_to_cudf():
+    cudf = pytest.importorskip("cudf")
+    source = ParquetSource(path2)
+    df = source.to_cudf()
+    assert df.shape == (2002, 7)
+    assert isinstance(df, cudf.DataFrame)


### PR DESCRIPTION
Adds a `to_cudf` method to allow reading parquet files into `cudf.DataFrame` objects. Fixes #17.

Let me know if I should add more docstrings or tests, this PR is fairly minimal at this point.

