### PR TITLE
Do not install the tests as a top level package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     maintainer='Martin Durant',
     maintainer_email='martin.durant@utoronto.ca',
     license='BSD',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     # package_data={'': ['*.pcap', '*.yml', '*.html']},
     entry_points={
         'intake.drivers': ['parquet = intake_parquet.source:ParquetSource']},


### PR DESCRIPTION
I noticed `intake-parquet` was distributing its `tests` folder as a top level package, i.e. it's in my `site-packages` folder. This happens because `find_packages()` look for folders that contain an `__init__.py` file, which is the case here. This PR excludes it. The `MANIFEST.in` file uses `recursive-include` in a way that the source distribution will include everything in from the `tests` folder, so I didn't touch it.

(I noticed this running `pytest --pyargs tests`)