### PR TITLE
fix storage_options passing on get schema

### DIFF
--- a/intake_parquet/source.py
+++ b/intake_parquet/source.py
@@ -50,7 +50,7 @@ class ParquetSource(base.DataSource):
     def _get_schema(self):
         if self._df is None:
             engine = self._kwargs.get("engine", "fastparquet")
-            fs, _, _ = fsspec.core.get_fs_token_paths(self._urlpath, **self._storage_options)
+            fs, _, _ = fsspec.core.get_fs_token_paths(self._urlpath, storage_options=self._storage_options)
             if engine == "fastparquet":
                 import fastparquet
                 pf = fastparquet.ParquetFile(self._urlpath, fs=fs)


### PR DESCRIPTION
Trying to discover a catalog on S3 bucket leads to a TypeError : 
`TypeError: get_fs_token_paths() got an unexpected keyword argument 'anon'`

```yaml
plugins:
  source:
    - module: intake_parquet
sources:
  test:
    description: Short example parquet data
    driver: parquet
    args:
      urlpath: s3://bucket/path/file.parquet
      storage_options:
        anon: True
        client_kwargs:
          endpoint_url: https://example.com
```
This PR fixes the way `storage_options` are passed to `get_fs_token_paths` in the [same way](https://github.com/intake/intake/blob/d5d668a0a488de01746a80253531ba011fe12822/intake/source/csv.py#L127) that builtin CSV plugin.
